### PR TITLE
Update model descriptions to schema version 1.0.1

### DIFF
--- a/construction-vessel/config/dp_controller_OspModelDescription.xml
+++ b/construction-vessel/config/dp_controller_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="ned_position">

--- a/construction-vessel/config/dp_reference_model_OspModelDescription.xml
+++ b/construction-vessel/config/dp_reference_model_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="vessel_setpoint">

--- a/construction-vessel/config/linearized_wave_model_OspModelDescription.xml
+++ b/construction-vessel/config/linearized_wave_model_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="first_order_disturbances">

--- a/construction-vessel/config/power_system_OspModelDescription.xml
+++ b/construction-vessel/config/power_system_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="bus_1_loads">

--- a/construction-vessel/config/thrust_allocation_OspModelDescription.xml
+++ b/construction-vessel/config/thrust_allocation_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="force_command">

--- a/construction-vessel/config/thruster_model_OspModelDescription.xml
+++ b/construction-vessel/config/thruster_model_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
 
         <Generic name="tunnel_thruster_1_command">

--- a/construction-vessel/config/vessel_model_OspModelDescription.xml
+++ b/construction-vessel/config/vessel_model_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         <Generic name="wind_forces">
             <Variable ref="wind_forces.surge"/>

--- a/construction-vessel/config/winch_OspModelDescription.xml
+++ b/construction-vessel/config/winch_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="power_consumption">

--- a/construction-vessel/config/wind_model_OspModelDescription.xml
+++ b/construction-vessel/config/wind_model_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         <Generic name="ned_position">
             <Variable ref="vessel_position.north"/>

--- a/dp-ship/DPController_OspModelDescription.xml
+++ b/dp-ship/DPController_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="m">
             <BaseUnit kg="0" m="1" s="0" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="0.0"/>

--- a/dp-ship/NLPobserver_OspModelDescription.xml
+++ b/dp-ship/NLPobserver_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="m">
             <BaseUnit kg="0" m="1" s="0" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="0.0"/>

--- a/dp-ship/OSOM_OspModelDescription.xml
+++ b/dp-ship/OSOM_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="m">
             <BaseUnit kg="0" m="1" s="0" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="0.0"/>

--- a/dp-ship/ReferenceGenerator_OspModelDescription.xml
+++ b/dp-ship/ReferenceGenerator_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="m">
             <BaseUnit kg="0" m="1" s="0" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="0.0"/>

--- a/dp-ship/ThMPC_OspModelDescription.xml
+++ b/dp-ship/ThMPC_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="rad">
             <BaseUnit kg="0" m="0" s="0" A="0" K="0" mol="0" cd="0" rad="1" factor="1.0" offset="0.0"/>

--- a/gunnerus-dp/fmus/BoxReference_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/BoxReference_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     
     <UnitDefinitions>
         <Unit name="m">

--- a/gunnerus-dp/fmus/ControlSystemCommunication_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/ControlSystemCommunication_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     
     <UnitDefinitions>
         <Unit name="m">

--- a/gunnerus-dp/fmus/CurrentModel_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/CurrentModel_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
         
     <UnitDefinitions>
         <Unit name="m/s">

--- a/gunnerus-dp/fmus/DPController_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/DPController_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     
     <UnitDefinitions>
         <Unit name="m">

--- a/gunnerus-dp/fmus/ReferenceModel_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/ReferenceModel_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     
     <UnitDefinitions>
         <Unit name="m">

--- a/gunnerus-dp/fmus/SimulatorCommunication_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/SimulatorCommunication_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     
     <UnitDefinitions>
         <Unit name="m">

--- a/gunnerus-dp/fmus/ThrusterDynamics_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/ThrusterDynamics_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     
      <UnitDefinitions>
         <Unit name="N">

--- a/gunnerus-dp/fmus/VesselModel_OspModelDescription.xml
+++ b/gunnerus-dp/fmus/VesselModel_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
         
     <UnitDefinitions>
         <Unit name="m">

--- a/gunnerus-palfinger-crane/config/ControlAllocatorGIFixedAngles_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/ControlAllocatorGIFixedAngles_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="N">
 			<BaseUnit kg="1" m="1" s="-2" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/DPController_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/DPController_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="N">
 			<BaseUnit kg="1" m="1" s="-2" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/NonlinearPassiveObserver_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/NonlinearPassiveObserver_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="N">
 			<BaseUnit kg="1" m="1" s="-2" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/PMAzimuth_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/PMAzimuth_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="m/s">
 			<BaseUnit kg="0" m="1" s="-1" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/PalfingerCrane_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/PalfingerCrane_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="N">
 			<BaseUnit kg="1" m="1" s="-2" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/PowerPlant_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/PowerPlant_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="V">
 			<BaseUnit kg="1" m="2" s="-3" A="-1" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/ThrusterDrive_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/ThrusterDrive_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="V">
 			<BaseUnit kg="1" m="2" s="-3" A="-1" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/TunnelThruster_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/TunnelThruster_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="m/s">
 			<BaseUnit kg="0" m="1" s="-1" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/VesselFmu_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/VesselFmu_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 		<Unit name="N">
 			<BaseUnit kg="1" m="1" s="-2" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="1.0"/>			

--- a/gunnerus-palfinger-crane/config/WaypointProvider3DOF_OspModelDescription.xml
+++ b/gunnerus-palfinger-crane/config/WaypointProvider3DOF_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 	<UnitDefinitions>
 	</UnitDefinitions>
 	<VariableGroups>

--- a/gunnerus-waypoint-following/config/Converter_OspModelDescription.xml
+++ b/gunnerus-waypoint-following/config/Converter_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 
     <VariableGroups>        
         <Generic name="rad_per_sec">

--- a/gunnerus-waypoint-following/config/PMAzimuth_OspModelDescription.xml
+++ b/gunnerus-waypoint-following/config/PMAzimuth_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 
     <VariableGroups>
         <Generic name="rpm">

--- a/gunnerus-waypoint-following/config/PowerPlant_OspModelDescription.xml
+++ b/gunnerus-waypoint-following/config/PowerPlant_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         <Generic name="azimuth_0_available_power">
             <Variable ref="p1.e[1]"/>

--- a/gunnerus-waypoint-following/config/ThrusterDrive_OspModelDescription.xml
+++ b/gunnerus-waypoint-following/config/ThrusterDrive_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     
     <VariableGroups>
         <Generic name="power_consumption">

--- a/gunnerus-waypoint-following/config/TrajectoryController_OspModelDescription.xml
+++ b/gunnerus-waypoint-following/config/TrajectoryController_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="position_3dof">

--- a/gunnerus-waypoint-following/config/VesselFmu_OspModelDescription.xml
+++ b/gunnerus-waypoint-following/config/VesselFmu_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="position_3dof">

--- a/gunnerus-waypoint-following/config/WaypointProvider2DOF_OspModelDescription.xml
+++ b/gunnerus-waypoint-following/config/WaypointProvider2DOF_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="target_wp">

--- a/lars/config/AFrameActuatorSetpoint_OspModelDescription.xml
+++ b/lars/config/AFrameActuatorSetpoint_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="a_frame_setpoint">

--- a/lars/config/AFrameActuator_OspModelDescription.xml
+++ b/lars/config/AFrameActuator_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="cylinder_gain">

--- a/lars/config/AFrameController_OspModelDescription.xml
+++ b/lars/config/AFrameController_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="a_frame_setpoint">

--- a/lars/config/AFrame_OspModelDescription.xml
+++ b/lars/config/AFrame_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="cylinder_force">

--- a/lars/config/WinchActuatorSetpoint_OspModelDescription.xml
+++ b/lars/config/WinchActuatorSetpoint_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="winch_setpoint">

--- a/lars/config/WinchActuator_OspModelDescription.xml
+++ b/lars/config/WinchActuator_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="motor_gain">

--- a/lars/config/WinchController_OspModelDescription.xml
+++ b/lars/config/WinchController_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="load_depth">

--- a/lars/config/winch_OspModelDescription.xml
+++ b/lars/config/winch_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         
         <Generic name="load_depth">

--- a/open-modelica-thruster/Thruster_Thruster_OspModelDescription.xml
+++ b/open-modelica-thruster/Thruster_Thruster_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
 
     <UnitDefinitions>
         <Unit name="m/s">

--- a/quarter-truck/LogConfig.xml
+++ b/quarter-truck/LogConfig.xml
@@ -1,11 +1,19 @@
-<simulators>
-    <simulator name="chassis">
-        <variable name="zChassis"/>
-    </simulator>
-    <simulator name="wheel">
-        <variable name="zWheel"/>
-    </simulator>
-	<simulator name="ground">
-        <variable name="zGround"/>
-    </simulator>
-</simulators>
+         <simulators>
+           <simulator name="chassis">
+             <variable name="zChassis"/>
+             <variable name="p.e"/>
+             <variable name="p.f"/>
+           </simulator>
+           <simulator name="wheel">
+             <variable name="zWheel"/>
+             <variable name="p1.e"/>
+             <variable name="p1.f"/>
+             <variable name="p.e"/>
+             <variable name="p.f"/>
+           </simulator>
+           <simulator name="ground">
+             <variable name="zGround"/>
+             <variable name="p.e"/>
+             <variable name="p.f"/>
+           </simulator>
+         </simulators>

--- a/quarter-truck/chassis_OspModelDescription.xml
+++ b/quarter-truck/chassis_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="m/s">
             <BaseUnit kg="0" m="1" s="-1" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="0.0"/>

--- a/quarter-truck/ground_OspModelDescription.xml
+++ b/quarter-truck/ground_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="m/s">
             <BaseUnit kg="0" m="1" s="-1" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="0.0"/>

--- a/quarter-truck/wheel_OspModelDescription.xml
+++ b/quarter-truck/wheel_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <UnitDefinitions>
         <Unit name="m/s">
             <BaseUnit kg="0" m="1" s="-1" A="0" K="0" mol="0" cd="0" rad="0" factor="1.0" offset="0.0"/>

--- a/sensors-and-senders/config/gps_sender_OspModelDescription.xml
+++ b/sensors-and-senders/config/gps_sender_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
 
         <Generic name="nmea_gga">

--- a/sensors-and-senders/config/gps_sensor_OspModelDescription.xml
+++ b/sensors-and-senders/config/gps_sensor_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
 
         <Generic name="gnss_input">

--- a/sensors-and-senders/config/gyro_sender_OspModelDescription.xml
+++ b/sensors-and-senders/config/gyro_sender_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         <Generic name="nmea_gyro">
            <Variable ref="Heading"/>

--- a/sensors-and-senders/config/gyro_sensor_OspModelDescription.xml
+++ b/sensors-and-senders/config/gyro_sensor_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
     
         <Generic name="gyro_input">

--- a/sensors-and-senders/config/vru_sender_OspModelDescription.xml
+++ b/sensors-and-senders/config/vru_sender_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         <Generic name="nmea_sxn">
             <Variable ref="Roll"/>

--- a/sensors-and-senders/config/vru_sensor_OspModelDescription.xml
+++ b/sensors-and-senders/config/vru_sensor_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         <Generic name="vru_input">
             <Variable ref="roll"/>

--- a/sensors-and-senders/config/wind_sensor_OspModelDescription.xml
+++ b/sensors-and-senders/config/wind_sensor_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
         <Generic name="windsensor_in">
             <Variable ref="wind_speed"/>

--- a/sensors-and-senders/config/wind_sensor_sender_OspModelDescription.xml
+++ b/sensors-and-senders/config/wind_sensor_sender_OspModelDescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
     <VariableGroups>
 
         <Generic name="nmea_mwv">

--- a/tutorial-fmus/Damper_OspModelDescription.xml
+++ b/tutorial-fmus/Damper_OspModelDescription.xml
@@ -1,4 +1,4 @@
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
   <UnitDefinitions>
     <Unit name="kilo_newton">
       <BaseUnit kg="1" m="1" s="-2" factor="1e-3"/>

--- a/tutorial-fmus/Mass_OspModelDescription.xml
+++ b/tutorial-fmus/Mass_OspModelDescription.xml
@@ -1,4 +1,4 @@
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
   <UnitDefinitions>
     <Unit name="newton">
       <BaseUnit kg="1" m="1" s="-2"/>

--- a/tutorial-fmus/Spring_OspModelDescription.xml
+++ b/tutorial-fmus/Spring_OspModelDescription.xml
@@ -1,4 +1,4 @@
-<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.0" version="1.0">
+<OspModelDescription xmlns="https://open-simulation-platform.com/OspModelDescription/1.0.1" version="1.0">
   <UnitDefinitions>
     <Unit name="newton">
       <BaseUnit kg="1" m="1" s="-2"/>


### PR DESCRIPTION
The newest osp-validator expects schema version 1.0.1 (was 1.0.0) for OspModelDescription.xml. It fails to parse with models that are still using 1.0.0 schema. 

Two ways to solve this I guess - update all the model descriptions as done in this PR, or I can submit a PR on osp-validator to also support schema version 1.0.0 via e.g. command line option. 